### PR TITLE
Updated to include major starting points for navigation and general styles / layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "jquery": "~1.11.3",
     "breakpoint-sass": "~2.6.1",
-    "modernizr": "~2.8.3"
+    "modernizr": "~2.8.3",
+    "jrespond": "*"
   }
 }

--- a/source/assets/javascripts/all.js
+++ b/source/assets/javascripts/all.js
@@ -1,1 +1,4 @@
 //= require jquery/dist/jquery
+//= require jrespond/jRespond
+//= require responders
+//= require navigation

--- a/source/assets/javascripts/navigation.js
+++ b/source/assets/javascripts/navigation.js
@@ -1,0 +1,115 @@
+
+var $menuTrigger = $('.menu-trigger'),
+    $primaryMenu = $('.primary-navigation'),
+    $utilityTrigger = $('.utility-trigger'),
+    $utilityMenu = $('.utility-navigation');
+
+function toggleTriggerClass() {
+  if (!$menuTrigger.hasClass('is-active')) {
+    $menuTrigger.addClass('is-active');
+  } else {
+    $menuTrigger.removeClass('is-active');
+  }
+};
+
+function toggleMenuClass() {
+  if (!$primaryMenu.hasClass('is-visible')) {
+    $primaryMenu.addClass('is-visible');
+  } else {
+    $primaryMenu.removeClass('is-visible');
+  }
+}
+
+function toggleMenu() {
+  $menuTrigger.on("click", function(e){
+    toggleTriggerClass();
+    toggleMenuClass();
+    $primaryMenu.slideToggle("fast");
+    // if utilityMenu is NOT visible, do nothing.
+    if (!$utilityMenu.is(':visible')) {
+      return
+    } else {
+    // if utilityMenu IS visible, reset the trigger and the menu (hide menu & remove classes/events).
+      resetUtilityTrigger();
+      $utilityMenu.removeClass('is-visible').slideUp('fast');
+    }
+  });
+};
+
+function resetMenu() {
+  if (!$primaryMenu.hasClass('is-visible')) {
+    $primaryMenu.removeAttr('style');
+  } else {
+    $primaryMenu.removeClass('is-visible').removeAttr('style');
+  }
+};
+
+function resetMenuTrigger() {
+  if (!$menuTrigger.hasClass('is-active')) {
+    return
+  } else {
+    $menuTrigger.removeClass('is-active');
+  }
+};
+
+function toggleUtilityTriggerClass() {
+  if (!$utilityTrigger.hasClass('is-active')) {
+    $utilityTrigger.addClass('is-active');
+  } else {
+    $utilityTrigger.removeClass('is-active');
+  }
+};
+
+function toggleUtilityMenuClass() {
+  if (!$utilityMenu.hasClass('is-visible')) {
+    $utilityMenu.addClass('is-visible');
+  } else {
+    $utilityMenu.removeClass('is-visible');
+  }
+};
+
+function toggleUtilityMenu() {
+  $utilityTrigger.on("click", function(e){
+    toggleUtilityTriggerClass();
+    toggleUtilityMenuClass();
+    $utilityMenu.slideToggle('fast');
+    // if primaryMenu is NOT visible, do nothing.
+    if (!$primaryMenu.is(':visible')) {
+      return
+    } else {
+    // if primaryMenu IS visible, reset the trigger and the menu (hide menu & remove classes/events).
+      resetMenuTrigger();
+      $primaryMenu.removeClass('is-visible').slideUp('fast');
+    }
+  });
+};
+
+function resetUtilityMenu() {
+  if (!$utilityMenu.hasClass('is-visible')) {
+    $utilityMenu.removeAttr('style');
+  } else {
+    $utilityMenu.removeClass('is-visible').removeAttr('style');
+  }
+};
+
+function resetUtilityTrigger() {
+  if (!$utilityTrigger.hasClass('is-active')) {
+    return
+  } else {
+    $utilityTrigger.removeClass('is-active');
+  }
+};
+
+// Fixes broken navigation when changing states on mobile then expanding to desktop
+jRes.addFunc({
+  breakpoint: 'nav',
+  exit: function(){
+    resetUtilityTrigger();
+    resetUtilityMenu();
+    resetMenu();
+    resetMenuTrigger();
+  }
+});
+
+toggleUtilityMenu();
+toggleMenu();

--- a/source/assets/javascripts/responders.js
+++ b/source/assets/javascripts/responders.js
@@ -1,0 +1,8 @@
+// call jRespond and add breakpoints
+var jRes = jRespond([
+  {
+    label: 'nav',
+    enter: 0,
+    exit: 700
+  }
+]);

--- a/source/assets/stylesheets/contexts/_site-header.scss
+++ b/source/assets/stylesheets/contexts/_site-header.scss
@@ -1,0 +1,19 @@
+.site-header {
+  @include pie-clearfix;
+
+  .site-name {
+    @include heading-4;
+    padding-top: 1em;
+    display: inline-block;
+    float: left;
+
+    @include breakpoint($breakpoint-xxl) {
+      @include heading-2;
+      padding-top: 0.5em;
+    }
+  }
+
+  .mobile-navigation {
+    float: right;
+  }
+}

--- a/source/assets/stylesheets/globals/_forms.scss
+++ b/source/assets/stylesheets/globals/_forms.scss
@@ -1,0 +1,145 @@
+// site-wide form styles
+
+// get rid of "default" iOS button styling for submit buttons
+input[type=submit] {
+  appearance: none;
+}
+
+input[type="submit"],
+button[type="submit"] {
+  @include button-form;
+}
+
+input[type="email"],
+input[type="password"],
+input[type="text"],
+input[type="tel"],
+input[type="number"],
+input[type="url"],
+textarea {
+  padding: 0.9em 1em;
+  border-radius: 2px 2px;
+  color: $text-color;
+  margin-left: 0;
+  margin-right: 0;
+  width: 100%;
+  max-width: 500px;
+  border: 1px $border-color solid;
+}
+
+select {
+  height: 3em;
+  line-height: 2.5em;
+  border: 1px solid $border-color;
+  width: 100%;
+}
+
+form label {
+  display: block;
+}
+
+fieldset {
+  margin-bottom: 1em;
+
+  legend {
+    @include title-face;
+    margin-bottom: 0.35em;
+  }
+}
+
+
+///// Form Layout
+
+form .input {
+  margin-bottom: 1em;
+}
+
+.legend-text {
+  display: inline-block;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+}
+
+.two-up {
+  @include clearfix;
+  > .input {
+    @include column(6);
+    margin-right: 0;
+    margin-left: $gutter-width;
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+}
+
+.two-up-wider {
+  @include clearfix;
+  @include breakpoint($breakpoint-s) {
+    > .input {
+      @include column(6);
+      margin-right: 0;
+      margin-left: $gutter-width;
+      &:first-child {
+        margin-left: 0;
+      }
+    }
+  }
+}
+
+.three-up {
+  @include clearfix;
+
+  .input {
+    @include column(4);
+    margin-right: 0;
+    margin-left: $gutter-width;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
+  &.zip-city-state {
+    // general input is the city
+    .input {
+      @include column(7);
+      @include breakpoint($breakpoint-s) {
+        @include column(6);
+      }
+      // first child is the zip
+      &:first-child {
+        @include column(12);
+        @include last;
+        @include breakpoint($breakpoint-s) {
+          @include column(3);
+        }
+      }
+      // select is the state
+      // .state may be a text field for certain countries
+      &.select, .state {
+        @include column(5);
+        @include last;
+        @include breakpoint($breakpoint-s) {
+          @include column(3);
+          @include last;
+        }
+      }
+    }
+  }
+}
+
+.three-up-wider {
+  @include clearfix;
+
+  .input {
+    @include breakpoint($breakpoint-s) {
+      @include column(4);
+      margin-right: 0;
+      margin-left: $gutter-width;
+
+      &:first-child {
+        margin-left: 0;
+      }
+    }
+  }
+}

--- a/source/assets/stylesheets/globals/_general.scss
+++ b/source/assets/stylesheets/globals/_general.scss
@@ -1,0 +1,162 @@
+// styles not specific to any particular site page.
+// place things like "general" paragraph styles, heading styles, base list styles, etc. here.
+
+// if you're calling the container mixin, you can define a custom max-width
+// otherwise, the max-width's default value is 81.25em (1300px)
+//.container {
+//  @include container(70em);
+//}
+
+* {
+  box-sizing: border-box;
+}
+
+.container {
+  // change your max-width like so:
+  // @include container(68.75em);
+  // default max-width is 81.25em (1300px)
+  @include container;
+  width: 95%;
+}
+
+html {
+  background-color: $footer-color;
+}
+
+body {}
+
+.main-content {
+  @include pie-clearfix;
+  padding-bottom: 1em;
+  background-color: $background-color;
+  padding-top: 1em;
+
+  .constrained {
+    max-width: 40em;
+    margin: 0 auto 0 auto;
+  }
+}
+
+
+// General Typographic Styles
+//////////////////////////////////////
+
+body {
+  @include copy-face;
+  color: $text-color;
+  line-height: 1.4;
+}
+
+////////// Block-level Elements
+
+p {
+  margin-bottom: 1em;
+}
+
+ul, ol {
+  li li {
+    font-size: inherit;
+  }
+}
+
+// In Main Content Area
+
+.primary {
+  ul, ol {
+    margin: 0 0 0.5em 2em;
+    li {
+      margin-bottom: 0.5em;
+    }
+  }
+
+  ul {
+    list-style: disc;
+    margin-top: 0.5em;
+  }
+
+  ol {
+    list-style: decimal;
+  }
+}
+
+///// Headings
+
+h1 {
+  @include heading-1;
+}
+
+h2 {
+  @include heading-2;
+}
+
+h3 {
+  @include heading-3;
+}
+
+h4 {
+  @include heading-4;
+}
+
+h5 {
+  @include heading-5;
+}
+
+h6 {
+  @include heading-6;
+}
+
+////////// Inline Elements
+
+a {
+  @include link;
+}
+
+strong, b {
+  font-weight: bold;
+}
+
+em, i {
+  font-style: italic;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.button {
+  @include button;
+}
+
+.button-highlight {
+  @include button-highlight;
+}
+
+.button-subtle {
+  @include button-subtle;
+}
+
+.button-reverse {
+  @include button-reverse;
+}
+
+.button-wrapper {
+  display: inline-block;
+
+  .note {
+    display: block;
+    text-align: center;
+    margin-top: 0.35em;
+  }
+}
+
+// Other elements
+//////////////////////////////////////
+
+.screenreader-text {
+  @include screenreader-text;
+}
+
+.not-visually-hidden {
+  @include not-visually-hidden;
+}

--- a/source/assets/stylesheets/library/_general-mixins.scss
+++ b/source/assets/stylesheets/library/_general-mixins.scss
@@ -3,10 +3,6 @@
   *zoom: 1;
 }
 
-.clearfix {
-  @include clearfix;
-}
-
 @mixin pie-clearfix {
   *zoom: 1;
   &:after {
@@ -16,6 +12,132 @@
   }
 }
 
-.pie-clearfix {
-  @include pie-clearfix;
+@mixin divider-bottom {
+  padding-bottom: 1em;
+  border-bottom: 1px solid $border-color;
+  margin-bottom: 1em;
+}
+
+@mixin divider-top {
+  padding-top: 1em;
+  border-top: 1px solid $border-color;
+  margin-top: 1em;
+}
+
+@mixin divider-right {
+  padding-right: 1em;
+  border-right: 1px solid $border-color;
+  margin-right: 1em;
+}
+
+@mixin divider-left {
+  padding-left: 1em;
+  border-left: 1px solid $border-color;
+  margin-left: 1em;
+}
+
+@mixin divider-none {
+  padding: 0;
+  border: 0 none;
+  margin: 0;
+}
+
+@mixin button {
+  border-radius: 4px 4px;
+  display: inline-block;
+  padding: 0.5em 1em;
+  text-decoration: none;
+  color: $background-color;
+  background-color: $link-color;
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    background-color: $link-color-hover;
+    color: $background-color;
+  }
+}
+
+@mixin button-highlight {
+  @include button;
+  background-color: $highlight-color;
+  &:hover,
+  &:focus {
+    background-color: $highlight-color-hover;
+  }
+}
+
+@mixin button-subtle {
+  @include button;
+  background-color: $background-color;
+  color: $link-color;
+  border: 1px solid $border-color;
+  &:hover,
+  &:focus {
+    color: $link-color;
+    background-color: $background-color-subtle;
+  }
+}
+
+@mixin button-reverse {
+  @include button;
+  background-color: $background-color-subtle;
+  color: $link-color;
+  &:hover,
+  &:focus {
+    color: $link-color-hover;
+    background-color: $background-color;
+  }
+}
+
+@mixin button-form {
+  @include button;
+  border: 0 none;
+  font-size: 1em;
+  &:hover,
+  &:focus {
+    cursor: pointer;
+  }
+}
+
+@mixin screenreader-text {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+@mixin not-visually-hidden {
+  border: inherit;
+  clip: inherit;
+  height: inherit;
+  margin: inherit;
+  overflow: inherit;
+  padding: inherit;
+  position: inherit;
+  width: inherit;
+}
+
+@mixin reset-list {
+  margin-left: 0;
+  margin-top: 0;
+  li {
+    list-style-type: none;
+  }
+}
+
+@mixin inline-list {
+  margin-bottom: 1.5em;
+
+  li {
+    display: inline;
+    margin-right: 0.25em;
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
 }

--- a/source/assets/stylesheets/library/_grid.scss
+++ b/source/assets/stylesheets/library/_grid.scss
@@ -19,6 +19,20 @@ $grid_width: ((($column_width+($gutter_width))*$columns)-$gutter_width);
   margin: auto;
   max-width: $max-width;
   *zoom: 1;
+
+  @include breakpoint($breakpoint-s) {
+    width: 85%;
+  }
+
+  @include breakpoint($breakpoint-l) {
+    width: 95%;
+  }
+
+  @if $legacy-support-for-ie8 {
+    // give IE8 a fixed-width!
+    max-width: 75em;
+    width: 75em;
+  }
 }
 
 @function column_width($num) {
@@ -53,25 +67,25 @@ $grid_width: ((($column_width+($gutter_width))*$columns)-$gutter_width);
 }
 
 @mixin last-col2 {
-  &:nth-of-type(1n) {
-    margin-right: $gutter-width;
-    .lt-ie8 & {
-      margin-right: $gutter_width - 0.25%;
-    }
-    float: left;
-    clear: none;
+  margin-right: $gutter-width;
+  .lt-ie8 & {
+    margin-right: $gutter_width - 0.25%;
   }
-  &:nth-of-type(2n+2) {
+  float: left;
+  clear: none;
+
+  &.last-col-2, &.last-col-4, &.last-col-6, &.last-col-8, &.last-col-10, &.last-col-12 {
     @include last;
     float: right;
   }
-  &:nth-of-type(2n+3) {
+
+  &.last-col-3, &.last-col-5, &.last-col-7, &.last-col-9, &.last-col-11, &.last-col-1 {
     clear: both;
   }
 }
 
 @mixin last-col3 {
-  &:nth-of-type(1n) {
+  &.last-col-1, &.last-col-2, &.last-col-3, &.last-col-4, &.last-col-5, &.last-col-6, &.last-col-7, &.last-col-8, &.last-col-9, &.last-col-10, &.last-col-11, &.last-col-12 {
     margin-right: $gutter-width;
     .lt-ie8 & {
       margin-right: $gutter_width - 0.25%;
@@ -79,17 +93,18 @@ $grid_width: ((($column_width+($gutter_width))*$columns)-$gutter_width);
     float: left;
     clear: none;
   }
-  &:nth-of-type(3n+3) {
+
+  &.last-col-3, &.last-col-6, &.last-col-9, &.last-col-12 {
     @include last;
     float: right;
   }
-  &:nth-of-type(3n+4) {
+  &.last-col-4, &.last-col-7, &.last-col-10, &.last-col-1 {
     clear: both;
   }
 }
 
 @mixin last-col4 {
-  &:nth-of-type(1n) {
+  &.last-col-1, &.last-col-2, &.last-col-3, &.last-col-4, &.last-col-5, &.last-col-6, &.last-col-7, &.last-col-8, &.last-col-9, &.last-col-10, &.last-col-11, &.last-col-12 {
     margin-right: $gutter-width;
     .lt-ie8 & {
       margin-right: $gutter_width - 0.25%;
@@ -97,17 +112,18 @@ $grid_width: ((($column_width+($gutter_width))*$columns)-$gutter_width);
     float: left;
     clear: none;
   }
-  &:nth-of-type(4n+4) {
+
+  &.last-col-4, &.last-col-8, &.last-col-12 {
     @include last;
     float: right;
   }
-  &:nth-of-type(4n+5) {
+  &.last-col-5, &.last-col-9, &.last-col-1 {
     clear: both;
   }
 }
 
 @mixin last-col6 {
-  &:nth-of-type(1n) {
+  &.last-col-1, &.last-col-2, &.last-col-3, &.last-col-4, &.last-col-5, &.last-col-6, &.last-col-7, &.last-col-8, &.last-col-9, &.last-col-10, &.last-col-11, &.last-col-12 {
     margin-right: $gutter-width;
     .lt-ie8 & {
       margin-right: $gutter_width - 0.25%;
@@ -115,11 +131,12 @@ $grid_width: ((($column_width+($gutter_width))*$columns)-$gutter_width);
     float: left;
     clear: none;
   }
-  &:nth-of-type(6n+6) {
+
+  &.last-col-6, &.last-col-12 {
     @include last;
     float: right;
   }
-  &:nth-of-type(6n+7) {
+  &.last-col-7, &.last-col-1 {
     clear: both;
   }
 }

--- a/source/assets/stylesheets/library/_mediaqueries.scss
+++ b/source/assets/stylesheets/library/_mediaqueries.scss
@@ -1,0 +1,18 @@
+@include breakpoint-set('to ems',true);
+
+// override if you want to provide a fixed-width stylesheet
+$legacy-support-for-ie8: false;
+
+//it's ok to put px values in here if you've set "to ems" to "true"!
+
+$breakpoint-xxs: 280px;
+$breakpoint-xs: 400px;
+$breakpoint-s: 500px;
+$breakpoint-m: 600px;
+$breakpoint-l: 700px;
+$breakpoint-nav: $breakpoint-l;
+$breakpoint-xl: 960px;
+$breakpoint-xxl: 1100px;
+
+// media query for hi-resolution displays
+$breakpoint-hi-res: 2 device-pixel-ratio;

--- a/source/assets/stylesheets/library/_typographic-mixins.scss
+++ b/source/assets/stylesheets/library/_typographic-mixins.scss
@@ -1,0 +1,79 @@
+// typographic mixins and extends
+
+@mixin copy-face {
+  font-family: georgia, "Times New Roman", times, serif;
+  font-weight: normal;
+}
+
+@mixin title-face {
+  font-family: arial, "helvetica neue", helvetica, sans-serif;
+  font-weight: bold;
+}
+
+@mixin link {
+  color: $link-color;
+  text-decoration: none;
+
+  &:hover, &:focus {
+    color: $link-color-hover;
+    text-decoration: underline;
+  }
+}
+
+@mixin link-reverse {
+  color: $background-color-subtle;
+  &:hover, &:focus {
+    color: $background-color;
+    text-decoration: none;
+  }
+}
+
+@mixin heading-link {
+  color: $heading-color;
+  text-decoration: none;
+
+  &:hover, &:focus {
+    color: darken($heading-color, 15%);
+    text-decoration: underline;
+  }
+}
+
+@mixin heading {
+  @include title-face;
+  margin-bottom: 0.35em;
+  line-height: 1.2;
+  color: $heading-color;
+  a {
+    @include heading-link;
+  }
+}
+
+@mixin heading-1 {
+  @include heading;
+  font-size: 2.5em;
+}
+
+@mixin heading-2 {
+  @include heading;
+  font-size: 1.8em;
+}
+
+@mixin heading-3 {
+  @include heading;
+  font-size: 1.4em;
+}
+
+@mixin heading-4 {
+  @include heading;
+  font-size: 1.2em;
+}
+
+@mixin heading-5 {
+  @include heading;
+  font-size: 1em;
+}
+
+@mixin heading-6 {
+  @include heading;
+  font-size: 0.875em;
+}

--- a/source/assets/stylesheets/library/_variables.scss
+++ b/source/assets/stylesheets/library/_variables.scss
@@ -1,0 +1,16 @@
+$text-color: #888;
+$heading-color: $text-color;
+$text-color-subtle: lighten($text-color, 30%);
+
+$link-color: #555;
+$link-color-hover: darken($link-color, 15%);
+
+$highlight-color: #333;
+$highlight-color-hover: darken($highlight-color, 15%);
+
+$border-color: #ccc;
+
+$background-color: #fff;
+$background-color-subtle: #eee;
+
+$footer-color: $link-color;

--- a/source/assets/stylesheets/main.scss
+++ b/source/assets/stylesheets/main.scss
@@ -9,8 +9,9 @@
 @import "library/general-mixins";
 
 @import "globals/forms.scss";
+@import "globals/general.scss";
 
 @import "contexts/site-header";
 @import "contexts/site-footer";
 
-@import "modules/primary-navigation";
+@import "modules/navigation";

--- a/source/assets/stylesheets/modules/_navigation.scss
+++ b/source/assets/stylesheets/modules/_navigation.scss
@@ -1,0 +1,132 @@
+.mobile-navigation {
+  @include pie-clearfix;
+  @include breakpoint($breakpoint-nav) {
+    display: none;
+  }
+}
+
+.menu-trigger, .utility-trigger {
+  border: 1px solid $border-color;
+  background-color: transparent;
+  color: $link-color;
+  font-size: 1.25em;
+  padding: 0.5em;;
+  margin: 0;
+  width: 48%;
+  float: right;
+
+  &:hover, &:focus {
+    cursor: pointer;
+  }
+}
+
+.utility-trigger {
+  margin-right: 2%;
+}
+
+.menu-trigger {
+
+}
+
+.site-header .container {
+  position: relative;
+}
+
+.primary-navigation, .utility-navigation {
+  display: none;
+  clear: both;
+  padding-top: 1em;
+  padding-bottom: 0.5em;
+
+  @include breakpoint($breakpoint-nav) {
+    display: block;
+  }
+
+  ul {
+    background-color: $background-color-subtle;
+    padding: 1em 0;
+
+    @include breakpoint($breakpoint-nav) {
+      background-color: inherit;
+      padding: 0;
+    }
+  }
+
+  li {
+    text-align: center;
+    padding-top: 1em;
+    margin-top: 1em;
+    border-top: 1px solid $border-color;
+
+    @include breakpoint($breakpoint-nav) {
+      display: inline-block;
+      @include divider-none;
+      text-align: left;
+    }
+
+    &:first-of-type {
+      padding-top: 0;
+      margin-top: 0;
+      border-top: 0 none;
+    }
+  }
+}
+
+.primary-navigation {
+  @include breakpoint($breakpoint-nav) {
+    ul {
+      li {
+        color: white !important;
+        margin-right: 1em;
+        padding-bottom: 0.5em;
+
+        &.last {
+          margin-right: 0;
+        }
+
+        a {
+          color: $text-color;
+        }
+      }
+    }
+  }
+}
+
+// use for things like user login/logout, other top-level, but lesser important links in header.
+.utility-navigation {
+  @include breakpoint($breakpoint-nav) {
+    padding-top: 0;
+    position: absolute;
+    top: 2em;
+    right: 0;
+    font-size: 0.8em;
+  }
+
+  li {
+    @include breakpoint($breakpoint-nav) {
+      margin-left: 0.75em;
+    }
+  }
+}
+
+///// Secondary Navigation on internal pages
+
+.secondary-navigation {
+  @include title-face;
+  border: 1px solid $border-color;
+  padding: 1em 0.5em 0.5em 0.5em;
+  margin-bottom: 1.5em;
+
+  ul {
+    margin: 0;
+
+    li {
+      @include divider-top;
+      list-style-type: none;
+    }
+
+    ul li {
+      padding-left: 1em;
+    }
+  }
+}

--- a/source/index.haml
+++ b/source/index.haml
@@ -3,4 +3,4 @@ title: Welcome to Stubbleman
 ---
 
 %h2.page-title
-	The Stubbleman is Watching
+  The Stubbleman is Watching

--- a/source/partials/_primary-navigation.haml
+++ b/source/partials/_primary-navigation.haml
@@ -1,0 +1,5 @@
+%nav.primary-navigation{role: "navigation"}
+  %ul.navigation-item-group
+    %li.nav-item= link_to 'Top', '#'
+    %li.nav-item= link_to 'Level', '#'
+    %li.nav-item= link_to 'Navigation', '#'

--- a/source/partials/_site-footer.haml
+++ b/source/partials/_site-footer.haml
@@ -1,3 +1,3 @@
 %footer.site-footer
-	%p.copyright
-		Copyright #{Date.today.year.to_s}. All rights reserved.
+  %p.copyright
+    Copyright #{Date.today.year.to_s}. All rights reserved.

--- a/source/partials/_site-header.haml
+++ b/source/partials/_site-header.haml
@@ -1,4 +1,11 @@
 %header.site-header
-	.container
-		%h1.site-name
-			Site Name
+  .container
+    %h1.site-name
+      Site Name
+
+    %section.mobile-navigation
+      %button.menu-trigger
+        %span.icon-menu
+        %span.trigger-text Menu
+
+    = partial 'partials/primary-navigation'


### PR DESCRIPTION
Adding primary navigation markup (mobile and full navigation)
Adding javascript to show / hide mobile navigation. (primary and utility)
Adding jrespond to required bower components
Adding javascript to reset nav when exiting breakpoint-nav boundary (jrespond)
Adding bearded's default global styles:
- Global form styles now found in stylesheets/globals/_forms partial.
- General element and layout styles in stylesheets/globals/_general partial.

Adding general mixins to the stylesheet library.
Adding most recent grid implementation, including a change from nth-col to numbered column classes for the last-col mixins which work with older IE at the expense of having to number columns with classnames.
Adding a set of default mediaqueries to the previously empty library file.
Adding default set of typographic mixins to stylesheet library.
Adding default greyscale wireframe colors to the stylesheets/libraries/_variables partial
Adding navigation starting point css rules.
Converted all tabs to spaces.
